### PR TITLE
Create a context struct for validation

### DIFF
--- a/testing/resource.go
+++ b/testing/resource.go
@@ -48,7 +48,7 @@ type ResourceSpec struct {
 	FieldWithValidation            string `json:"fieldWithValidation,omitempty"`
 	FieldThatsImmutable            string `json:"fieldThatsImmutable,omitempty"`
 	FieldThatsImmutableWithDefault string `json:"fieldThatsImmutableWithDefault,omitempty"`
-	FieldThatCallbackRejects       string `json:"fieldThatCallbackRejects,omitempty"`
+	FieldForCallbackValidation     string `json:"fieldThatCallbackRejects,omitempty"`
 }
 
 // GetGroupVersionKind returns the GroupVersionKind.

--- a/webhook/resourcesemantics/validation/validation.go
+++ b/webhook/resourcesemantics/validation/validation.go
@@ -49,7 +49,7 @@ import (
 var errMissingNewObject = errors.New("the new object may not be nil")
 
 // Callback is a generic function to be called by a consumer of validation
-type Callback func(context.Context, *unstructured.Unstructured) error
+type Callback func(Context, *unstructured.Unstructured) error
 
 // reconciler implements the AdmissionController for resources
 type reconciler struct {
@@ -261,7 +261,9 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 		unstruct := &unstructured.Unstructured{}
 		unstruct.SetUnstructuredContent(uns)
 
-		if err := callback(ctx, unstruct); err != nil {
+		vCtx := NewValidationContext(ctx, ac, req)
+
+		if err := callback(*vCtx, unstruct); err != nil {
 			return err
 		}
 	}

--- a/webhook/resourcesemantics/validation/validation_context.go
+++ b/webhook/resourcesemantics/validation/validation_context.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Context wraps information relevant for validation of the incoming request along with the generic context.Context.
+type Context struct {
+	// CallCtx is the context from the user-request.
+	CallCtx context.Context
+
+	// Operation is the operation being performed. This may be different than the operation
+	// requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+	Operation admissionv1beta1.Operation
+
+	// DryRun indicates that this request will not be persisted.
+	// Any operations with persistent side-effects should be skipped.
+	DryRun bool
+
+	// KubeClient is a client for interacting with k8s APIs.
+	KubeClient kubernetes.Interface
+}
+
+// NewValidationContext copies relevant objects from the request to a single structure to be read during validation.
+func NewValidationContext(ctx context.Context, ac *reconciler, req *admissionv1beta1.AdmissionRequest) (vc *Context) {
+	dryRun := false
+	if req.DryRun != nil && *req.DryRun {
+		dryRun = true
+	}
+
+	vc = &Context{
+		CallCtx:    ctx,
+		Operation:  req.Operation,
+		DryRun:     dryRun,
+		KubeClient: ac.client,
+	}
+	return
+}

--- a/webhook/resourcesemantics/validation/validation_test.go
+++ b/webhook/resourcesemantics/validation/validation_test.go
@@ -111,7 +111,7 @@ var (
 	}
 )
 
-func resourceCallback(ctx context.Context, uns *unstructured.Unstructured) error {
+func resourceCallback(ctx Context, uns *unstructured.Unstructured) error {
 
 	var resource Resource
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(uns.UnstructuredContent(), &resource); err != nil {


### PR DESCRIPTION
Issue #1140

**Proposed Changes**
This creates a struct to be passed along to validation callbacks that contains resources needed to perform validation actions.

This gives a more concrete place for strongly-typed data and documentation (over the generic context.Context) and serves as a place we will be able to place additional data onto.